### PR TITLE
📈: Polish draft release note and add auto-labeler

### DIFF
--- a/.github/auto-labeler.yml
+++ b/.github/auto-labeler.yml
@@ -1,0 +1,56 @@
+# enable auto-labeler on prs.
+enable:
+  prs: true
+
+# Labels is an object where:
+# - keys are labels
+# - values are objects of { include: [ pattern ], exclude: [ pattern ] }
+#    - pattern must be a valid regex, and is applied globally to
+#      title + description of issues and/or prs (see enabled config above)
+#    - 'include' patterns will associate a label if any of these patterns match
+#    - 'exclude' patterns will ignore this label if any of these patterns match
+labels:
+  'feature':
+    include:
+      - '\b:seedling::\b'
+      - '\b🌱:\b'
+  'bug':
+    include:
+      - '\b:bug::\b'
+      - '\b🐛:\b'
+  'improvement':
+    include:
+      - '\b:sparkles::\b'
+      - '\b✨:\b'
+  'doc':
+    include:
+      - '\b:black_nib::\b'
+      - '\b✒️:\b'
+  'chore':
+    include:
+      - '\b:art::\b'
+      - '\b🎨:\b'
+      - '\b:recycle::\b'
+      - '\b♻️:\b'
+      - '\b:white_check_mark::\b'
+      - '\b✅:\b'
+      - '\b:hammer_and_pick::\b'
+      - '\b⚒️:\b'
+      - '\b:chart_with_upwards_trend::\b'
+      - '\b📈:\b'
+      - '\b:memo::\b'
+      - '\b📝:\b'
+      - '\b:rewind::\b'
+      - '\b⏪:\b'
+  'performance':
+    include:
+      - '\b:zap::\b'
+      - '\b⚡️:\b'
+  'BREAKING CHANGE':
+    include:
+      - '\b:bomb::\b'
+      - '\b💣:\b'
+  'deps':
+    include:
+      - '\b:arrow_up::\b'
+      - '\b⬆️:\b'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,25 +1,32 @@
-name-template: ':bookmark: v$NEXT_PATCH_VERSION'
+name-template: '$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
-  - title: '✨ Features'
+  - title: '💣 BREAKING CHANGES'
+    labels:
+      - 'BREAKING CHANGE'
+  - title: '🌱 New Features'
     labels:
       - 'feature'
-      - 'enhancement'
+  - title: '✨ Improvements'
+    labels:
+      - 'improvement'
+      - 'performance'
   - title: '🐛 Bug Fixes'
     labels:
       - 'bug'
   - title: '✒ Documentation'
     labels:
-      - 'documentation'
-  - title: '🔧 Maintenance'
-    labels:
-      - 'chore'
+      - 'doc'
   - title: '⬆️ Dependency Updates'
     labels:
       - 'deps'
 exclude-labels:
   - 'chore'
+  - 'no release note'
 change-template: '- $TITLE (#$NUMBER)'
+replacers:
+  - search: '\b(:seedling:|🌱|:bug:|🐛|:sparkles:|✨|:black_nib:|✒️|:bomb:|💣|:arrow_up:|⬆️):\b'
+    replace: ''
 template: |
   ## Changes
 

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,3 +1,7 @@
+# DISABLED
+#   Semantic Pull Request allows only ASCII characters(`\w` or `[a-zA-Z0-9_]`) for types.
+#     https://github.com/tunnckoCoreLabs/parse-commit-message/blob/93018525c85296b44b41ddb7af1700afd5a54d60/src/header.js#L40
+
 # About Conventional Commits
 #   English: https://www.conventionalcommits.org/en/v1.0.0/
 #   日本語: https://www.conventionalcommits.org/ja/v1.0.0-beta.4/

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
-  "commitMessagePrefix": ":arrow_up: ",
-  "labels": ["deps"],
+  "commitMessagePrefix": "⬆️: ",
   "extends": [
     "config:base"
   ],


### PR DESCRIPTION
Configure GitHub Apps do generate more clean draft release notes.

* Remove type which is redundant with the header from the commit messages.
* Reorganized release note categories and labels.
* Change Renovate PR prefix according to auto-labeler configurations.