### PR TITLE
⚒️: Detect compiler warnings as errors, add generally useful test libraries, and misc changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,12 @@
                   <dependency>org.testcontainers:*</dependency>
                 </dependencies>
               </requireSameVersions>
+              <!--
+                   This rule checks the dependencies and fails if any snapshots are found.
+              -->
+              <requireReleaseDeps>
+                <onlyWhenRelease>true</onlyWhenRelease>
+              </requireReleaseDeps>
             </rules>
             <fail>true</fail>
           </configuration>

--- a/selidor-projects/selidor-dependencies/pom.xml
+++ b/selidor-projects/selidor-dependencies/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -36,7 +37,7 @@
   </developers>
 
   <scm>
-    <url>${git.url}/selidor-projects/selidor-dependencies</url>
+    <url>${git.url}/selidor-projects/${project.artifactId</url>
     <connection>${git.connection}</connection>
     <developerConnection>${git.developerConnection}</developerConnection>
     <tag>${git.refname}</tag>
@@ -89,6 +90,11 @@
   <dependencyManagement>
     <dependencies>
       <!-- Selidor -->
+      <dependency>
+        <groupId>pw.itr0.selidor</groupId>
+        <artifactId>selidor-identifier</artifactId>
+        <version>${revision}</version>
+      </dependency>
 
       <!-- Spring -->
       <dependency>

--- a/selidor-projects/selidor-parent/pom.xml
+++ b/selidor-projects/selidor-parent/pom.xml
@@ -214,8 +214,10 @@
             <parameters>true</parameters>
             <compilerArgs>
               <!-- Javacで警告が出たときは、コンパイルエラーとして扱います。 -->
-              <compilerArg>-Werror</compilerArg>
+              <arg>-Werror</arg>
             </compilerArgs>
+            <!-- showWarningsをtrueにしないと、警告が出た時にコンパイルエラーとして扱うことができません。 -->
+            <showWarnings>true</showWarnings>
           </configuration>
         </plugin>
 

--- a/selidor-projects/selidor-parent/pom.xml
+++ b/selidor-projects/selidor-parent/pom.xml
@@ -171,6 +171,8 @@
             </execution>
           </executions>
           <configuration>
+            <!-- リモートリポジトリの情報は取得しないようにします。 -->
+            <offline>true</offline>
             <!-- ビルドのログにGitのリビジョン情報を出力します。 -->
             <verbose>true</verbose>
             <!-- 日付のフォーマットはISO8601に合わせておきます。 -->

--- a/selidor-projects/selidor-parent/pom.xml
+++ b/selidor-projects/selidor-parent/pom.xml
@@ -355,4 +355,28 @@
       </plugin>
     </plugins>
   </build>
+
+  <!-- 基本的なテストライブラリを追加しておきます。 -->
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/selidor-projects/selidor-parent/pom.xml
+++ b/selidor-projects/selidor-parent/pom.xml
@@ -37,7 +37,7 @@
   </developers>
 
   <scm>
-    <url>${git.url}/selidor-projects/selidor-parent</url>
+    <url>${git.url}/selidor-projects/${project.artifactId</url>
     <connection>${git.connection}</connection>
     <developerConnection>${git.developerConnection}</developerConnection>
     <tag>${git.refname}</tag>

--- a/selidor-projects/selidor-starters/selidor-starter-parent/pom.xml
+++ b/selidor-projects/selidor-starters/selidor-starter-parent/pom.xml
@@ -149,6 +149,8 @@
             </execution>
           </executions>
           <configuration>
+            <!-- リモートリポジトリの情報は取得しないようにします。 -->
+            <offline>true</offline>
             <!-- ビルドのログにGitのリビジョン情報を出力します。 -->
             <verbose>true</verbose>
             <!-- 日付のフォーマットはISO8601に合わせておきます。 -->

--- a/selidor-projects/selidor-starters/selidor-starter-parent/pom.xml
+++ b/selidor-projects/selidor-starters/selidor-starter-parent/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -17,7 +18,7 @@
   <url>${git.url}</url>
 
   <scm>
-    <url>${git.url}/selidor-projects/selidor-starters/selidor-starter-parent</url>
+    <url>${git.url}/selidor-projects/selidor-starters/${project.artifactId</url>
     <connection>${git.connection}</connection>
     <developerConnection>${git.developerConnection}</developerConnection>
     <tag>${git.refname}</tag>


### PR DESCRIPTION
## Changes

* Detect compiler warnings as errors
* Add generally useful test libraries to `selidor-parent`
* Enforce release version when releasing


## ⚒️: Detect compiler warnings as errors

### Description

Change `showWarnings` configuration of `maven-compiler-plugin` to `true`.

### Context

`maven-compiler-plugin` does not report compiler warnings by default (`showWarnings=false`).

So, even if `-Werror` is set in compiler argument and IntelliJ IDEA is reporting compile warning, `maven-compiler-plugin:compile` successfully finishes.


## ⚒️: Add generally useful test libraries to `selidor-parent`

### Description

Add dependencies on generally useful test libraries like JUnit5 to `selidor-parent`.

* JUnit5
* AssertJ

### Context

Add test libraries in each module is very painful.


## ⚒️: Enforce release version when releasing

### Description

Enable `requireReleaseDeps` of `maven-enforcer-plugin` when module is releasing.

### Context

Obviously, `SNAPSHOT` reference is very dangerous.

## ⚒️: Skip collecting Git information from remote repository

### Description

Make `git-commit-id-plugin` to run offline.

### Context

`git-commit-id-plugin` reports an authentication error while collecting git information from remote repository.

But there is no need to collect information from the remote repository, disabled it.